### PR TITLE
prevent replacing sendmail link

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -79,7 +79,7 @@ class mailhog::install inherits mailhog {
   }
 
   # Deploy mhsendmail
-  file { ['/usr/local/bin/mhsendmail','/usr/sbin/sendmail']:
+  file { ['/usr/local/bin/mhsendmail']:
     ensure  => file,
     source  => 'puppet:///modules/mailhog/mhsendmail',
     owner   => 'root',


### PR DESCRIPTION
this can break ifup on debian 10 as /etc/network/if-up.d/postfix relies on standard sendmail